### PR TITLE
feat: create a ci job in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+# FIXME: master -> main
+on:
+  push:
+    branches: 
+        - 'master'
+        - 'RELEASE-*'
+  pull_request:
+    branches:
+        - 'master'
+        - 'RELEASE-*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        java-version: [ '21' ] # TODO add 25
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Set up JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+        cache: maven
+    - name: Build project
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
Before starting work on the code update section of #161
Create a CI job that will run in GitHub to verify the changes created will build properly.